### PR TITLE
fix: rebuild load data, order disposal, validate delimiter options

### DIFF
--- a/src/PetToys.TemplatedConfigurationProvider/ConfigurationBuilderExtensions.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/ConfigurationBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class ConfigurationBuilderExtensions
     {
         var options = new TemplatedConfigurationOptions();
         optionBuilder?.Invoke(options);
+        options.Validate();
 
         return builder.Add(new TemplatedConfigurationSource(options));
     }

--- a/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationOptions.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace PetToys.TemplatedConfigurationProvider;
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace PetToys.TemplatedConfigurationProvider;
 
 /// <summary>
 /// Options to configure TemplatedConfigurationProvider.
@@ -14,4 +17,38 @@ public sealed class TemplatedConfigurationOptions
     /// Gets or sets the end character of the pattern. Removed when replaced.
     /// </summary>
     public char TemplateCharacterEnd { get; set; } = '}';
+
+    /// <summary>
+    /// Validates the configured delimiter characters, throwing
+    /// <see cref="ArgumentException"/> for combinations the parser cannot handle.
+    /// </summary>
+    internal void Validate()
+    {
+        if (TemplateCharacterStart == TemplateCharacterEnd)
+        {
+            throw new ArgumentException(
+                $"{nameof(TemplateCharacterStart)} and {nameof(TemplateCharacterEnd)} must differ.",
+                nameof(TemplateCharacterStart));
+        }
+
+        ValidateCharacter(TemplateCharacterStart, nameof(TemplateCharacterStart));
+        ValidateCharacter(TemplateCharacterEnd, nameof(TemplateCharacterEnd));
+    }
+
+    private static void ValidateCharacter(char value, string propertyName)
+    {
+        if (value.ToString() == ConfigurationPath.KeyDelimiter)
+        {
+            throw new ArgumentException(
+                $"{propertyName} ('{value}') conflicts with the configuration key delimiter ('{ConfigurationPath.KeyDelimiter}').",
+                propertyName);
+        }
+
+        if (char.IsWhiteSpace(value) || char.IsControl(value))
+        {
+            throw new ArgumentException(
+                $"{propertyName} must not be a whitespace or control character.",
+                propertyName);
+        }
+    }
 }

--- a/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
@@ -15,6 +15,7 @@ internal sealed class TemplatedConfigurationProvider
     private readonly char _endChar;
     private readonly ConfigurationRoot _root;
     private readonly IDisposable _changeTokenRegistration;
+    private bool _disposed;
 
     public TemplatedConfigurationProvider(TemplatedConfigurationOptions options, IConfigurationBuilder builder)
     {
@@ -30,10 +31,7 @@ internal sealed class TemplatedConfigurationProvider
 
     public override void Load()
     {
-        foreach (var (key, value) in GetInnerData())
-        {
-            Data[key] = value;
-        }
+        Data = new Dictionary<string, string?>(GetInnerData(), StringComparer.OrdinalIgnoreCase);
     }
 
     private void Reload()
@@ -161,7 +159,10 @@ internal sealed class TemplatedConfigurationProvider
 
     public void Dispose()
     {
-        _root.Dispose();
+        if (_disposed) return;
+        _disposed = true;
+
         _changeTokenRegistration.Dispose();
+        _root.Dispose();
     }
 }

--- a/templated-configuration-provider.slnx
+++ b/templated-configuration-provider.slnx
@@ -11,6 +11,7 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/Solution Items/.github/">
+    <File Path=".github/dependabot.yml" />
     <File Path=".github/PULL_REQUEST_TEMPLATE.md" />
   </Folder>
   <Folder Name="/Solution Items/.github/ISSUE_TEMPLATE/">

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationOptionsValidationTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationOptionsValidationTest.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace PetToys.TemplatedConfigurationProvider.Tests;
+
+public sealed class TemplatedConfigurationOptionsValidationTest
+{
+    [Fact]
+    public void AddTemplatedConfiguration_EqualCharacters_Throws()
+    {
+        var act = () => new ConfigurationBuilder()
+            .AddTemplatedConfiguration(opt =>
+            {
+                opt.TemplateCharacterStart = '|';
+                opt.TemplateCharacterEnd = '|';
+            });
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*must differ*");
+    }
+
+    [Theory]
+    [InlineData(':', '}')]
+    [InlineData('{', ':')]
+    public void AddTemplatedConfiguration_KeyDelimiterCharacter_Throws(char start, char end)
+    {
+        var act = () => new ConfigurationBuilder()
+            .AddTemplatedConfiguration(opt =>
+            {
+                opt.TemplateCharacterStart = start;
+                opt.TemplateCharacterEnd = end;
+            });
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*key delimiter*");
+    }
+
+    [Theory]
+    [InlineData(' ', '}')]
+    [InlineData('{', '\t')]
+    [InlineData('\n', '}')]
+    [InlineData('\0', '}')]
+    public void AddTemplatedConfiguration_WhitespaceOrControlCharacter_Throws(char start, char end)
+    {
+        var act = () => new ConfigurationBuilder()
+            .AddTemplatedConfiguration(opt =>
+            {
+                opt.TemplateCharacterStart = start;
+                opt.TemplateCharacterEnd = end;
+            });
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddTemplatedConfiguration_DistinctPrintableCharacters_RegistersAndResolves()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Url"] = "https://<Svc:Tenant>.example.com",
+                ["Svc:Tenant"] = "acme",
+            })
+            .AddTemplatedConfiguration(opt =>
+            {
+                opt.TemplateCharacterStart = '<';
+                opt.TemplateCharacterEnd = '>';
+            })
+            .Build();
+
+        configuration["Svc:Url"].Should().Be("https://acme.example.com");
+    }
+}

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderDisposeTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderDisposeTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace PetToys.TemplatedConfigurationProvider.Tests;
+
+public sealed class TemplatedConfigurationProviderDisposeTest
+{
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        var provider = BuildProvider(out _);
+
+        var act = () =>
+        {
+            provider.Dispose();
+            provider.Dispose();
+        };
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SourceChange_BeforeDispose_TriggersReload()
+    {
+        // Sanity check that the harness actually drives a reload, so the
+        // post-dispose assertion below cannot pass vacuously.
+        var provider = BuildProvider(out var source);
+        var token = provider.GetReloadToken();
+
+        source.SetValue("Svc:Tenant", "changed");
+
+        token.HasChanged.Should().BeTrue();
+        provider.Dispose();
+    }
+
+    [Fact]
+    public void SourceChange_AfterDispose_TriggersNoReload()
+    {
+        var provider = BuildProvider(out var source);
+        var token = provider.GetReloadToken();
+
+        provider.Dispose();
+        source.SetValue("Svc:Tenant", "changed");
+
+        token.HasChanged.Should().BeFalse();
+    }
+
+    private static TemplatedConfigurationProvider BuildProvider(out TriggerableConfigurationSource source)
+    {
+        source = new TriggerableConfigurationSource(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Svc:Url"] = "https://{Svc:Tenant}.example.com",
+            ["Svc:Tenant"] = "acme",
+        });
+
+        var builder = new ConfigurationBuilder();
+        builder.Sources.Add(source);
+
+        var provider = new TemplatedConfigurationProvider(new TemplatedConfigurationOptions(), builder);
+        provider.Load();
+        return provider;
+    }
+}

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderLoadTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderLoadTest.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace PetToys.TemplatedConfigurationProvider.Tests;
+
+public sealed class TemplatedConfigurationProviderLoadTest
+{
+    [Fact]
+    public void Load_AfterSourceKeyRemoved_DropsStaleTemplatedKey()
+    {
+        var provider = BuildProvider(out var source);
+
+        provider.TryGet("Svc:Url", out var initial).Should().BeTrue();
+        initial.Should().Be("https://acme.example.com");
+
+        // Removing the referenced placeholder source key means "Svc:Url" no
+        // longer produces a templated value; a re-Load must drop the stale key.
+        source.RemoveQuiet("Svc:Tenant");
+        provider.Load();
+
+        provider.TryGet("Svc:Url", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Load_AfterPlaceholderValueChanged_ReflectsNewValue()
+    {
+        var provider = BuildProvider(out var source);
+
+        source.SetQuiet("Svc:Tenant", "contoso");
+        provider.Load();
+
+        provider.TryGet("Svc:Url", out var value).Should().BeTrue();
+        value.Should().Be("https://contoso.example.com");
+    }
+
+    private static TemplatedConfigurationProvider BuildProvider(out TriggerableConfigurationSource source)
+    {
+        source = new TriggerableConfigurationSource(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Svc:Url"] = "https://{Svc:Tenant}.example.com",
+            ["Svc:Tenant"] = "acme",
+        });
+
+        var builder = new ConfigurationBuilder();
+        builder.Sources.Add(source);
+
+        var provider = new TemplatedConfigurationProvider(new TemplatedConfigurationOptions(), builder);
+        provider.Load();
+        return provider;
+    }
+}

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderTest.cs
@@ -36,7 +36,6 @@ public sealed class TemplatedConfigurationProviderTest
         ["RelativeReference6:OpenIdConnectOptions:Authority:TenantId"] = "F8E5CAF8-325E-4975-8A5A-C0494B5FCACB",
 
         ["AbsoluteReference3:TwoValues"] = "qwe{Replacements:EmptyValue}asd{Replacements:Value}zxc",
-        ["AbsoluteReference4:TwoValues"] = "qwe|Replacements:EmptyValue|as|d|Replacements:Value|zxc",
 
         ["Replacements:NullValue"] = null,
         ["Replacements:EmptyValue"] = string.Empty,
@@ -50,7 +49,6 @@ public sealed class TemplatedConfigurationProviderTest
         ["Replacements:DifficultSituation3"] = "{}}{{}{{{{{}Lorem}}{{}{ipsum}}}}{{}}{}}}}{{{Value}{{dolor}}{{}}{}sit{{}{{{}",
 
         ["Replacements:DifficultSituation4"] = "|||]]]}]]]]]|||||]]|[[[][][||]Replacements:Value|[]}}}}[{}}}[]}",
-        ["Replacements:DifficultSituation5"] = "{L|(o)re^*m|Replacements:Value| gt)({[]][} ipsum dolor sit",
     };
 
     private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
@@ -63,15 +61,6 @@ public sealed class TemplatedConfigurationProviderTest
         .AddTemplatedConfiguration(opt =>
         {
             opt.TemplateCharacterStart = ']';
-            opt.TemplateCharacterEnd = '|';
-        })
-        .Build();
-
-    private readonly IConfigurationRoot _configurationWithOptionsModificator2 = new ConfigurationBuilder()
-        .AddInMemoryCollection(MemoryData)
-        .AddTemplatedConfiguration(opt =>
-        {
-            opt.TemplateCharacterStart = '|';
             opt.TemplateCharacterEnd = '|';
         })
         .Build();
@@ -134,15 +123,6 @@ public sealed class TemplatedConfigurationProviderTest
     public void TemplatedConfiguration_OptionsModificator1(string key, string expected)
     {
         var value = _configurationWithOptionsModificator1.GetValue<string>(key);
-        value.Should().Be(expected);
-    }
-
-    [Theory]
-    [InlineData("Replacements:DifficultSituation5", "{L|(o)re^*mPJVr[6}Zr{yBz}GQ2U6Fj0My gt)({[]][} ipsum dolor sit")]
-    [InlineData("AbsoluteReference4:TwoValues", "qweas|dPJVr[6}Zr{yBz}GQ2U6Fj0Myzxc")]
-    public void TemplatedConfiguration_OptionsModificator2(string key, string expected)
-    {
-        var value = _configurationWithOptionsModificator2.GetValue<string>(key);
         value.Should().Be(expected);
     }
 }

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TriggerableConfigurationSource.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TriggerableConfigurationSource.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+
+namespace PetToys.TemplatedConfigurationProvider.Tests;
+
+/// <summary>
+/// A test configuration source backed by a mutable dictionary. It lets a test
+/// mutate the underlying data either silently (<see cref="SetQuiet"/>,
+/// <see cref="RemoveQuiet"/>) or with a reload notification (<see cref="SetValue"/>),
+/// so both the explicit <c>Load</c> path and the change-token path can be driven
+/// deterministically without touching the file system.
+/// </summary>
+internal sealed class TriggerableConfigurationSource(IDictionary<string, string?> initialData) : IConfigurationSource
+{
+    private TriggerableProvider? _provider;
+
+    /// <summary>Changes a value and fires a reload notification.</summary>
+    public void SetValue(string key, string? value) => _provider?.SetValue(key, value);
+
+    /// <summary>Changes a value without firing a reload notification.</summary>
+    public void SetQuiet(string key, string? value) => _provider?.SetQuiet(key, value);
+
+    /// <summary>Removes a key without firing a reload notification.</summary>
+    public void RemoveQuiet(string key) => _provider?.RemoveQuiet(key);
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+        => _provider = new TriggerableProvider(initialData);
+
+    private sealed class TriggerableProvider(IDictionary<string, string?> initialData) : ConfigurationProvider
+    {
+        public override void Load()
+            => Data = new Dictionary<string, string?>(initialData, StringComparer.OrdinalIgnoreCase);
+
+        public void SetValue(string key, string? value)
+        {
+            Data[key] = value;
+            OnReload();
+        }
+
+        public void SetQuiet(string key, string? value) => Data[key] = value;
+
+        public void RemoveQuiet(string key) => Data.Remove(key);
+    }
+}


### PR DESCRIPTION
- Load rebuilds the provider data from the current source snapshot so keys whose source disappeared no longer leave stale templated values after an IConfigurationRoot.Reload().
- Dispose releases the change-token registration before the inner root and is idempotent, so no reload callback runs against a disposed root.
- AddTemplatedConfiguration validates the template delimiter options and throws ArgumentException for equal, key-delimiter (':'), or whitespace/control characters.
- Reference .github/dependabot.yml from the solution file.

refs #7, #8, #9
