### PR TITLE
Add strict mode for unresolved placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ The start and end characters must differ, must not be the configuration key
 delimiter (`:`), and must not be whitespace or control characters; otherwise
 `AddTemplatedConfiguration` throws an `ArgumentException`.
 
+### Strict mode
+
+By default unresolved placeholders are left untouched. To fail fast when a
+balanced placeholder cannot be resolved, enable strict mode:
+
+```csharp
+builder.Configuration.AddTemplatedConfiguration(opt =>
+{
+    opt.ThrowOnUnresolvedPlaceholders = true;
+});
+```
+
 ### Reload support
 
 When the provider sits on top of a reloadable source (for example a JSON file
@@ -182,8 +194,9 @@ not woken up for no-op reloads.
 - **Substitution is single-pass.** Placeholders are expanded against the *raw*
   source values, not recursively. If a referenced value itself contains a
   placeholder, it is inserted verbatim rather than expanded again.
-- **Unresolved placeholders pass through untouched.** A placeholder whose key
-  cannot be resolved (or an unbalanced delimiter) is left in the value as-is.
+- **Unresolved placeholders pass through untouched by default.** A placeholder
+  whose key cannot be resolved (or an unbalanced delimiter) is left in the
+  value as-is unless strict mode is enabled.
 - **Order matters.** The provider overrides values from the sources registered
   before it. Place it after those sources, and after it any source that should
   win over the templated result (such as command-line arguments).

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ not woken up for no-op reloads.
 - **Substitution is single-pass.** Placeholders are expanded against the *raw*
   source values, not recursively. If a referenced value itself contains a
   placeholder, it is inserted verbatim rather than expanded again.
-- **Unresolved placeholders pass through untouched by default.** A placeholder
-  whose key cannot be resolved (or an unbalanced delimiter) is left in the
-  value as-is unless strict mode is enabled.
+- **Unresolved placeholders pass through untouched by default.** A balanced
+  placeholder whose key cannot be resolved is left in the value as-is unless
+  strict mode is enabled. Unbalanced delimiters are always left unchanged.
 - **Order matters.** The provider overrides values from the sources registered
   before it. Place it after those sources, and after it any source that should
   win over the templated result (such as command-line arguments).

--- a/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationOptions.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationOptions.cs
@@ -19,6 +19,12 @@ public sealed class TemplatedConfigurationOptions
     public char TemplateCharacterEnd { get; set; } = '}';
 
     /// <summary>
+    /// Gets or sets a value indicating whether unresolved placeholders should
+    /// throw during configuration loading instead of passing through unchanged.
+    /// </summary>
+    public bool ThrowOnUnresolvedPlaceholders { get; set; }
+
+    /// <summary>
     /// Validates the configured delimiter characters, throwing
     /// <see cref="ArgumentException"/> for combinations the parser cannot handle.
     /// </summary>

--- a/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
@@ -38,7 +38,16 @@ internal sealed class TemplatedConfigurationProvider
 
     private void Reload()
     {
-        var newData = BuildTemplatedData();
+        Dictionary<string, string?> newData;
+        try
+        {
+            newData = BuildTemplatedData();
+        }
+        catch (InvalidOperationException) when (_throwOnUnresolvedPlaceholders)
+        {
+            return;
+        }
+
         if (DataEquals(Data, newData))
         {
             return;

--- a/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
@@ -13,6 +13,7 @@ internal sealed class TemplatedConfigurationProvider
 {
     private readonly char _startChar;
     private readonly char _endChar;
+    private readonly bool _throwOnUnresolvedPlaceholders;
     private readonly ConfigurationRoot _root;
     private readonly IDisposable _changeTokenRegistration;
     private bool _disposed;
@@ -21,6 +22,7 @@ internal sealed class TemplatedConfigurationProvider
     {
         _startChar = options.TemplateCharacterStart;
         _endChar = options.TemplateCharacterEnd;
+        _throwOnUnresolvedPlaceholders = options.ThrowOnUnresolvedPlaceholders;
         var otherProviders = builder.Sources
             .Where(s => s.GetType() != typeof(TemplatedConfigurationSource))
             .Select(source => source.Build(builder))
@@ -109,6 +111,7 @@ internal sealed class TemplatedConfigurationProvider
             var keyStart = start + 1;
             var searchFrom = keyStart;
             var matched = false;
+            string? unresolvedKey = null;
 
             while (true)
             {
@@ -116,6 +119,7 @@ internal sealed class TemplatedConfigurationProvider
                 if (end == -1) break;
 
                 var key = value[keyStart..end];
+                unresolvedKey ??= key;
                 if (TryGetReplacement(data, originalKey, key, out var rep))
                 {
                     sb.Append(value, i, start - i);
@@ -130,6 +134,12 @@ internal sealed class TemplatedConfigurationProvider
             }
 
             if (matched) continue;
+
+            if (_throwOnUnresolvedPlaceholders && unresolvedKey is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Configuration key '{originalKey}' contains unresolved placeholder '{unresolvedKey}'.");
+            }
 
             sb.Append(value, i, start - i);
             sb.Append(_startChar);

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderReloadSemanticsTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderReloadSemanticsTest.cs
@@ -67,6 +67,25 @@ public sealed class TemplatedConfigurationProviderReloadSemanticsTest
     }
 
     [Fact]
+    public void Reload_StrictModePlaceholderKeyRemoved_KeepsPreviousDataAndDoesNotSignal()
+    {
+        using var harness = new TemplatedProviderHarness(
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Url"] = "https://{Svc:Tenant}.example.com",
+                ["Svc:Tenant"] = "acme",
+            },
+            opt => opt.ThrowOnUnresolvedPlaceholders = true);
+        var token = harness.Provider.GetReloadToken();
+
+        harness.Source.Remove("Svc:Tenant");
+
+        token.HasChanged.Should().BeFalse();
+        harness.Provider.TryGet("Svc:Url", out var value).Should().BeTrue();
+        value.Should().Be("https://acme.example.com");
+    }
+
+    [Fact]
     public void Reload_NoTemplatedChange_DoesNotSignal()
     {
         using var harness = new TemplatedProviderHarness(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderResolutionTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderResolutionTest.cs
@@ -70,6 +70,34 @@ public sealed class TemplatedConfigurationProviderResolutionTest : IDisposable
     }
 
     [Fact]
+    public void Resolution_StrictMode_UnresolvedPlaceholder_Throws()
+    {
+        var act = () => Build(
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Url"] = "https://{Svc:Missing}.example.com",
+            },
+            opt => opt.ThrowOnUnresolvedPlaceholders = true);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Svc:Url*Svc:Missing*");
+    }
+
+    [Fact]
+    public void Resolution_StrictMode_ResolvedPlaceholder_Resolves()
+    {
+        var config = Build(
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Url"] = "https://{Svc:Tenant}.example.com",
+                ["Svc:Tenant"] = "acme",
+            },
+            opt => opt.ThrowOnUnresolvedPlaceholders = true);
+
+        config["Svc:Url"].Should().Be("https://acme.example.com");
+    }
+
+    [Fact]
     public void Resolution_EmptyPlaceholder_PassesThroughVerbatim()
     {
         var config = Build(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderResolutionTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderResolutionTest.cs
@@ -97,6 +97,21 @@ public sealed class TemplatedConfigurationProviderResolutionTest : IDisposable
         config["Svc:Url"].Should().Be("https://acme.example.com");
     }
 
+    [Theory]
+    [InlineData("https://{Svc:Missing.example.com")]
+    [InlineData("https://Svc:Missing}.example.com")]
+    public void Resolution_StrictMode_UnbalancedDelimiter_PassesThroughVerbatim(string raw)
+    {
+        var config = Build(
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Url"] = raw,
+            },
+            opt => opt.ThrowOnUnresolvedPlaceholders = true);
+
+        config["Svc:Url"].Should().Be(raw);
+    }
+
     [Fact]
     public void Resolution_EmptyPlaceholder_PassesThroughVerbatim()
     {


### PR DESCRIPTION
Closes #20

/claim #20

## Summary
- Add `ThrowOnUnresolvedPlaceholders` to opt into fail-fast placeholder resolution.
- Throw `InvalidOperationException` when a balanced placeholder cannot be resolved in strict mode.
- Keep the default lenient pass-through behavior and document strict mode.
- Add tests for unresolved and resolved placeholders in strict mode.

## Tests
- `dotnet format templated-configuration-provider.slnx --verify-no-changes --no-restore`
- `dotnet test test/PetToys.TemplatedConfigurationProvider.Tests/PetToys.TemplatedConfigurationProvider.Tests.csproj --no-restore` (passed for net8.0, net9.0, net10.0)