### PR TITLE
Resolve placeholders only against preceding sources

### DIFF
--- a/assets/RELEASE-NOTES.txt
+++ b/assets/RELEASE-NOTES.txt
@@ -1,3 +1,17 @@
+10.2.3
+======
+
+Fixed:
+- Placeholder resolution now reads only the configuration sources registered
+  before AddTemplatedConfiguration(). Previously the provider also resolved
+  against sources added after it (for example command-line arguments), so a
+  later source could silently feed a placeholder even though it is meant to win
+  over the templated result rather than supply it. Such a source no longer
+  satisfies a placeholder; the value is left verbatim. The documented "register
+  it after the sources it reads" arrangement is unaffected.
+
+--------------------------------------------------------------------------------
+
 10.2.2
 ======
 

--- a/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationProvider.cs
@@ -18,14 +18,18 @@ internal sealed class TemplatedConfigurationProvider
     private readonly IDisposable _changeTokenRegistration;
     private bool _disposed;
 
-    public TemplatedConfigurationProvider(TemplatedConfigurationOptions options, IConfigurationBuilder builder)
+    public TemplatedConfigurationProvider(
+        TemplatedConfigurationOptions options,
+        IConfigurationBuilder builder,
+        TemplatedConfigurationSource source)
     {
         _startChar = options.TemplateCharacterStart;
         _endChar = options.TemplateCharacterEnd;
         _throwOnUnresolvedPlaceholders = options.ThrowOnUnresolvedPlaceholders;
         var otherProviders = builder.Sources
+            .TakeWhile(s => !ReferenceEquals(s, source))
             .Where(s => s.GetType() != typeof(TemplatedConfigurationSource))
-            .Select(source => source.Build(builder))
+            .Select(s => s.Build(builder))
             .ToList();
         _root = new ConfigurationRoot(otherProviders);
         _changeTokenRegistration = ChangeToken.OnChange(_root.GetReloadToken, Reload);

--- a/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationSource.cs
+++ b/src/PetToys.TemplatedConfigurationProvider/TemplatedConfigurationSource.cs
@@ -8,6 +8,6 @@ internal sealed class TemplatedConfigurationSource(
 {
     public IConfigurationProvider Build(IConfigurationBuilder builder)
     {
-        return new TemplatedConfigurationProvider(options, builder);
+        return new TemplatedConfigurationProvider(options, builder, this);
     }
 }

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderCompositionTest.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedConfigurationProviderCompositionTest.cs
@@ -10,6 +10,8 @@ namespace PetToys.TemplatedConfigurationProvider.Tests;
 
 public sealed class TemplatedConfigurationProviderCompositionTest : IDisposable
 {
+    private readonly List<IDisposable> _roots = [];
+
     private readonly IConfigurationRoot _configuration = new ConfigurationBuilder()
         .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
@@ -38,5 +40,58 @@ public sealed class TemplatedConfigurationProviderCompositionTest : IDisposable
         result.Should().BeSameAs(builder);
     }
 
-    public void Dispose() => ((IDisposable)_configuration).Dispose();
+    [Fact]
+    public void Resolution_SourceRegisteredAfterProvider_DoesNotSatisfyPlaceholder()
+    {
+        // The templated value precedes the provider; the key it references is
+        // supplied only by a source registered *after* AddTemplatedConfiguration.
+        // That later source must not feed resolution, so the placeholder is left
+        // verbatim and the templated provider emits no value for the key.
+        var root = Build(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Url"] = "https://{Svc:Tenant}.example.com",
+            })
+            .AddTemplatedConfiguration()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Tenant"] = "acme",
+            }));
+
+        var templated = root.Providers.OfType<TemplatedConfigurationProvider>().Single();
+        templated.TryGet("Svc:Url", out _).Should().BeFalse();
+        root["Svc:Url"].Should().Be("https://{Svc:Tenant}.example.com");
+    }
+
+    [Fact]
+    public void Resolution_SourceRegisteredBeforeProvider_SatisfiesPlaceholder()
+    {
+        // Regression guard: both the templated value and its referenced key are
+        // supplied by sources preceding the provider, so resolution still works.
+        var root = Build(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Svc:Url"] = "https://{Svc:Tenant}.example.com",
+                ["Svc:Tenant"] = "acme",
+            })
+            .AddTemplatedConfiguration());
+
+        root["Svc:Url"].Should().Be("https://acme.example.com");
+    }
+
+    private IConfigurationRoot Build(IConfigurationBuilder builder)
+    {
+        var root = builder.Build();
+        _roots.Add((IDisposable)root);
+        return root;
+    }
+
+    public void Dispose()
+    {
+        ((IDisposable)_configuration).Dispose();
+        foreach (var root in _roots)
+        {
+            root.Dispose();
+        }
+    }
 }

--- a/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedProviderHarness.cs
+++ b/test/PetToys.TemplatedConfigurationProvider.Tests/TemplatedProviderHarness.cs
@@ -25,7 +25,10 @@ internal sealed class TemplatedProviderHarness : IDisposable
         var builder = new ConfigurationBuilder();
         builder.Sources.Add(Source);
 
-        Provider = new TemplatedConfigurationProvider(options, builder);
+        var templatedSource = new TemplatedConfigurationSource(options);
+        builder.Sources.Add(templatedSource);
+
+        Provider = new TemplatedConfigurationProvider(options, builder, templatedSource);
         Provider.Load();
     }
 


### PR DESCRIPTION
The provider built its inner resolution snapshot from every other source on the builder, including ones registered after AddTemplatedConfiguration(). A later source (for example command-line arguments) could silently satisfy a placeholder even though it is meant to win over the templated result rather than feed it.

Pass the source instance into the provider and snapshot only the sources that precede it in registration order. Add behavioral tests for the after/before cases and bump the release notes to 10.2.3.

refs #15

